### PR TITLE
chore: add "Validate PR" workflow

### DIFF
--- a/.github/actions/dotnet-setup/action.yml
+++ b/.github/actions/dotnet-setup/action.yml
@@ -1,0 +1,20 @@
+name: dotnet-setup
+description: setup the dotnet environment, global tools and whatever else is needed
+
+inputs:
+  dotnet-versions:
+    description: the dotnet version(s) to install and use
+    required: true
+
+runs:
+  using: 'composite'
+
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 100
+        fetch-tags: true
+
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ inputs.dotnet-versions }}

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -39,9 +39,6 @@ jobs:
           --logger "trx;LogFileName=unit-tests.trx"
 
       - name: Run integration tests
-        env:
-          ApiBaseUrl: http://localhost:5000
-          UseFakeAuth: true
         run: dotnet test src/integration-tests/integration-tests.csproj
           --no-restore
           --logger "trx;LogFileName=integration-tests.trx"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,53 @@
+name: "Validate PR"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  # ====================================================================
+  # C# tests
+  # ====================================================================
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: setup
+        uses: ./.github/actions/dotnet-setup
+        name: setup and configure dotnet
+        with:
+          dotnet-versions: 8.x
+
+      - name: Restore NuGet packages
+        run: dotnet restore
+
+      - name: Build solution
+        run: dotnet build --no-restore
+
+      - name: Run unit tests
+        run: dotnet test src/unit-tests/unit-tests.csproj
+          --no-build
+          --logger "trx;LogFileName=unit-tests.trx"
+
+      - name: Run integration tests
+        env:
+          ApiBaseUrl: http://localhost:5000
+          UseFakeAuth: true
+        run: dotnet test src/integration-tests/integration-tests.csproj
+          --no-restore
+          --logger "trx;LogFileName=integration-tests.trx"
+
+      - name: Publish Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/*.trx'

--- a/src/unit-tests/unit-tests.csproj
+++ b/src/unit-tests/unit-tests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" /> <!-- To fix a build error in CI -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/unit-tests/unit-tests.csproj
+++ b/src/unit-tests/unit-tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" /> <!-- To fix a build error in CI -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" /> <!-- To fix a build error in CI -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
This PR...

- adds a `validate pr` workflow, which builds and runs the unit and integration tests
- had to add some direct installs to the `unit-tests` project in order to fix package version errors (that lots of people seem to run into with Roslyn... sigh)