### PR TITLE
chore(gh-3): add release creation through workflows

### DIFF
--- a/.github/actions/dotnet-nuget/action.yml
+++ b/.github/actions/dotnet-nuget/action.yml
@@ -1,0 +1,46 @@
+name: dotnet-nuget
+description: Dotnet nuget pack and publish action. Depends on dotnet-setup action.
+
+inputs:
+  target-dir:
+    description: The build target directory
+    required: true
+  do-push:
+    description: Push the package to the nuget feed
+    required: false
+    default: 'true'
+  nuget-feed-access-token:
+    description: the access token for the nuget feed
+    required: false
+    type: string
+    default: ''
+  nuget-feed-uri:
+    description: the nuget feed to use
+    required: false
+    default: 'https://api.nuget.org/v3/index.json'
+    type: string
+
+runs:
+  using: 'composite'
+
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 100
+        fetch-tags: true
+
+    - id: dotnet-build
+      name: Dotnet build
+      run: dotnet build --configuration Release ${{ inputs.target-dir }}
+      shell: bash
+
+    - id: dotnet-pack
+      name: Dotnet pack
+      run: dotnet pack --configuration Release ${{ inputs.target-dir }}
+      shell: bash
+
+    - id: dotnet-publish
+      if: inputs.do-push == 'true'
+      name: Dotnet publish
+      run: dotnet nuget push "${{ inputs.target-dir }}/bin/Release/*.nupkg" --api-key ${{ inputs.nuget-feed-access-token }} --source ${{ inputs.nuget-feed-uri }}
+      shell: bash

--- a/.github/actions/pr-lint/action.yml
+++ b/.github/actions/pr-lint/action.yml
@@ -12,6 +12,8 @@ runs:
     - name: Lint PR title
       id: lint-pr-title
       uses: ./.github/actions/pr-lint/title
+      with:
+        github-token: ${{ inputs.github-token }}
     
     # Report on the error of the preceding step
     - if: always() && (steps.lint-pr-title.outputs.error_message != null)

--- a/.github/actions/pr-lint/action.yml
+++ b/.github/actions/pr-lint/action.yml
@@ -25,8 +25,8 @@ runs:
           The PR title must follow the [Conventional Commits specification(https://www.conventionalcommits.org/en/v1.0.0/) and this PR does not 😔
           
           A few examples:
-            feat(gh-123): heroic feature added
-            fix(GH-653): santa's junk
+            - feat(gh-123): heroic feature added
+            - fix(GH-653): santa's junk
           
           Details from the linter:
           ```

--- a/.github/actions/pr-lint/action.yml
+++ b/.github/actions/pr-lint/action.yml
@@ -1,0 +1,40 @@
+name: pr-lint
+description: Lint the PR according to our rules
+
+inputs:
+  github-token:
+    description: "Github token from the workflow"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Lint PR title
+      id: lint-pr-title
+      uses: ./.github/actions/pr-lint/title
+    
+    # Report on the error of the preceding step
+    - if: always() && (steps.lint-pr-title.outputs.error_message != null)
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: pr-title-lint-error
+        message: |
+          The PR title must follow the [Conventional Commits specification(https://www.conventionalcommits.org/en/v1.0.0/) and this PR does not 😔
+          
+          A few examples:
+            feat(gh-123): heroic feature added
+            fix(GH-653): santa's junk
+          
+          Details from the linter:
+          ```
+          ${{ steps.lint-pr-title.outputs.error_message }}
+          ```
+
+    # Delete previous PR comment when the linter is happy
+    - if: ${{ steps.lint-pr-title.outputs.error_message == null }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: pr-title-lint-error
+        delete: true

--- a/.github/actions/pr-lint/title/action.yml
+++ b/.github/actions/pr-lint/title/action.yml
@@ -1,0 +1,30 @@
+name: pr-lint/title
+description: Lint the PR title according to semantic commit rules
+
+inputs:
+  github-token:
+    description: "Github token from the workflow"
+    required: true
+
+outputs: 
+  error_message:
+    description: Error message from the validation of the PR title
+    value: ${{ steps.lint-pr-title.outputs.error_message }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate PR title
+      id: lint-pr-title
+      uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        # Configure which scopes are allowed (newline-delimited).
+        # These are regex patterns auto-wrapped in `^ $`.
+        scopes: |
+          deps-dev
+          deps
+          gh-\d+
+          GH-\d+
+        requireScope: true

--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -1,0 +1,62 @@
+name: "Create new version"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+
+jobs:
+  new-version:
+    runs-on: ubuntu-latest
+    outputs:
+      new-release-version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - id: setup
+        uses: ./.github/actions/dotnet-setup
+        name: setup and configure dotnet
+        with:
+          dotnet-versions: 8.x
+      
+      - id: dotnet-version
+        name: Install dotnet version
+        shell: bash
+        run: |
+          dotnet tool install --global dotnet-version-cli --version 3.0.3
+      
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/exec
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  publish-nuget-package:
+    runs-on: ubuntu-latest
+    needs: [ new-version ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./.github/actions/dotnet-setup@v2
+        name: setup and configure dotnet
+        with:
+          dotnet-versions: 8.x
+
+      - uses: ./.github/actions/dotnet-nuget
+        name: Publish nuget package
+        with:
+          target-dir: src/generator
+          set-new-version: ${{ needs.new-version.outputs.new-release-version }}
+          do-push: false # let's first see if this works
+          nuget-feed-access-token: "wait-for-it" # ${{ secrets.PACKAGE_PUSH_TOKEN }}
+          nuget-feed-uri: ""

--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -37,7 +37,7 @@ jobs:
           extra_plugins: |
             @semantic-release/exec
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN_PAT }}
 
   publish-nuget-package:
     runs-on: ubuntu-latest
@@ -56,7 +56,5 @@ jobs:
         name: Publish nuget package
         with:
           target-dir: src/generator
-          set-new-version: ${{ needs.new-version.outputs.new-release-version }}
           do-push: false # let's first see if this works
           nuget-feed-access-token: "wait-for-it" # ${{ secrets.PACKAGE_PUSH_TOKEN }}
-          nuget-feed-uri: ""

--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -57,4 +57,4 @@ jobs:
         with:
           target-dir: src/generator
           do-push: false # let's first see if this works
-          nuget-feed-access-token: "wait-for-it" # ${{ secrets.PACKAGE_PUSH_TOKEN }}
+          nuget-feed-access-token: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,30 @@
+name: "PR lint"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request: 
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr-lint:
+    name: Check PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pr-lint
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,0 +1,30 @@
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+    branches: ['main'],
+    plugins: [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "releaseRules": [
+                    {"type": "chore", "release": "patch"},
+                ],
+            }
+        ],
+        '@semantic-release/release-notes-generator',
+        [
+            "@semantic-release/exec",
+            {
+                "prepareCmd": "./version.sh ${nextRelease.version}",
+            }
+        ],
+        [
+            '@semantic-release/git',
+            {
+                message: 'chore(release): v${nextRelease.version}',
+            },
+        ],
+        '@semantic-release/github',
+    ],
+};

--- a/src/generator/generator.csproj
+++ b/src/generator/generator.csproj
@@ -11,13 +11,18 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <AssemblyName>Runedur.Generator</AssemblyName>
+    <AssemblyName>Runedur</AssemblyName>
     <PackageId>Runedur</PackageId>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <Title>Runedur</Title>
+    <Authors>Pingvinen</Authors>
+    <Company>Runedur</Company>
+    <PackageTags>ORM;Postgres;Timescaledb</PackageTags>
+    <PackageProjectUrl>https://github.com/pingvinen/runedur-orm</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/generator/generator.csproj
+++ b/src/generator/generator.csproj
@@ -25,6 +25,12 @@
     <PackageProjectUrl>https://github.com/pingvinen/runedur-orm</PackageProjectUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- Avoids using the same folders across projects, when building multiple projects at the same time, which leads to deadlocks -->
+    <OutputPath>bin/$(Configuration)/$(MSBuildProjectName)/</OutputPath>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />

--- a/src/integration-tests/integration-tests.csproj
+++ b/src/integration-tests/integration-tests.csproj
@@ -23,6 +23,11 @@
     </PackageReference>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- Avoids using the same folders across projects, when building multiple projects at the same time, which leads to deadlocks -->
+    <OutputPath>bin/$(Configuration)/$(MSBuildProjectName)/</OutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\generator\generator.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>

--- a/src/unit-tests/EntityAttributeGeneratorTests.cs
+++ b/src/unit-tests/EntityAttributeGeneratorTests.cs
@@ -24,7 +24,7 @@ namespace Runedur
     /// Marks a class as an entity that Runedur should
     /// consider during code generation
     /// </summary>
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""Runedur.Generator"", ""{version}"")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""Runedur"", ""{version}"")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = false)]
     internal sealed class RunedurEntityAttribute : global::System.Attribute
     {{

--- a/src/unit-tests/unit-tests.csproj
+++ b/src/unit-tests/unit-tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" /> <!-- To fix a build error in CI -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" /> <!-- To fix a build error in CI -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" /> <!-- This seems to be needed by the testing stack - do NOT include in production code -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/unit-tests/unit-tests.csproj
+++ b/src/unit-tests/unit-tests.csproj
@@ -27,6 +27,11 @@
     </PackageReference>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- Avoids using the same folders across projects, when building multiple projects at the same time, which leads to deadlocks -->
+    <OutputPath>bin/$(Configuration)/$(MSBuildProjectName)/</OutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\generator\generator.csproj" />
   </ItemGroup>

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 NEW_VERSION_FROM_SEMANTIC_RELEASE"
+  exit 1
+fi
+
+VERSION="$1"
+
+find . -type f -name '*.csproj' -print0 | xargs -0 -I {} dotnet version --skip-vcs --project-file {} "$VERSION"


### PR DESCRIPTION
This PR...

- adds a workflow for linting the PR itself (just the title for now)
- adda a workflow for creating a new semantic version and publishing the package to nuget
- adds various scripts and actions to make the above happen
- sets additional properties in the .csproj file related to the published package

Note that the new version workflow does not actually push to nuget yet!

Fixes #3 